### PR TITLE
Add support for Firefox Marionette Driver

### DIFF
--- a/bin/selenium-standalone
+++ b/bin/selenium-standalone
@@ -14,7 +14,7 @@ which('java', function javaFound(err, javaPath) {
   }
 
   var argv = minimist(process.argv.slice(2), {
-    string: ['version', 'drivers.chrome.version', 'drivers.ie.version']
+    string: ['version', 'drivers.chrome.version', 'drivers.ie.version', 'drivers.firefox.version']
   });
 
   var action = argv._[0];

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -5,7 +5,8 @@ var util = require('util');
 var urls = {
   selenium: '%s/%s/selenium-server-standalone-%s.jar',
   chrome: '%s/%s/chromedriver_%s.zip',
-  ie: '%s/%s/IEDriverServer_%s_%s.zip'
+  ie: '%s/%s/IEDriverServer_%s_%s.zip',
+  firefox: '%s/v%s/geckodriver-%s-%s'
 };
 
 function computeDownloadUrls(opts, askedOpts) {
@@ -37,6 +38,15 @@ function computeDownloadUrls(opts, askedOpts) {
       opts.drivers.ie.version
     );
   }
+  if (opts.drivers.firefox) {
+    downloadUrls.firefox = util.format(
+      urls.firefox,
+      opts.drivers.firefox.baseURL,
+      opts.drivers.firefox.version,
+      opts.drivers.firefox.version,
+      getFirefoxDriverArchitecture()
+    );
+  }
   return downloadUrls;
 }
 
@@ -64,4 +74,18 @@ function getIeDriverArchitecture(wanted) {
   }
 
   return platform;
+}
+
+function getFirefoxDriverArchitecture() {
+  var platform, type = '.gz';
+
+  if (process.platform === 'linux') {
+    platform = 'linux64';
+  } else if (process.platform === 'darwin') {
+    platform = 'OSX';
+  } else {
+    platform = 'win32';
+    type = '.zip';
+  }
+  return platform + type;
 }

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -6,7 +6,7 @@ var urls = {
   selenium: '%s/%s/selenium-server-standalone-%s.jar',
   chrome: '%s/%s/chromedriver_%s.zip',
   ie: '%s/%s/IEDriverServer_%s_%s.zip',
-  firefox: '%s/v%s/geckodriver-%s-%s'
+  firefox: '%s/v%s/geckodriver-%s%s-%s'
 };
 
 function computeDownloadUrls(opts, askedOpts) {
@@ -43,6 +43,7 @@ function computeDownloadUrls(opts, askedOpts) {
       urls.firefox,
       opts.drivers.firefox.baseURL,
       opts.drivers.firefox.version,
+      process.platform === 'win32' ? 'v' : '',
       opts.drivers.firefox.version,
       getFirefoxDriverArchitecture()
     );

--- a/lib/compute-fs-paths.js
+++ b/lib/compute-fs-paths.js
@@ -18,6 +18,12 @@ function computeFsPaths(opts) {
     };
   }
 
+  if (opts.drivers.firefox) {
+    fsPaths.firefox = {
+      installPath: path.join(opts.basePath, 'geckodriver', opts.drivers.firefox.version + '-' + opts.drivers.firefox.arch + '-geckodriver')
+    };
+  }
+
   fsPaths.selenium = {
     installPath: path.join(opts.basePath, 'selenium-server', opts.seleniumVersion + '-server.jar')
   };
@@ -27,6 +33,8 @@ function computeFsPaths(opts) {
 
     if (name === 'selenium') {
       downloadPath = newFsPaths[name].installPath;
+    } else if (name === 'firefox' && process.platform !== 'win32') {
+      downloadPath = newFsPaths[name].installPath + '.gz';
     } else {
       downloadPath = newFsPaths[name].installPath + '.zip';
     }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -11,6 +11,11 @@ module.exports = {
       version: '2.53.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
+    },
+    firefox: {
+      version: '0.8.0',
+      arch: process.arch,
+      baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
     }
   }
 };

--- a/lib/install.js
+++ b/lib/install.js
@@ -84,6 +84,10 @@ function install(opts, cb) {
     tasks.push(chmodChromeDr.bind(null, fsPaths.chrome.installPath));
   }
 
+  if (fsPaths.firefox) {
+    tasks.push(chmodChromeDr.bind(null, fsPaths.firefox.installPath));
+  }
+
   async.series(tasks, function(err) {
     cb(err, fsPaths);
   });
@@ -135,6 +139,14 @@ function install(opts, cb) {
       });
     }
 
+    if (opts.fsPaths.firefox) {
+      installers.push({
+        installer: installFirefoxDr,
+        from: opts.urls.firefox,
+        to: opts.fsPaths.firefox.downloadPath
+      })
+    }
+
     var steps = installers.map(function (opts) {
       return onlyInstallMissingFiles.bind(null, opts);
     });
@@ -163,6 +175,44 @@ function install(opts, cb) {
     installZippedFile(opts.from, opts.to, cb);
   }
 
+  function installFirefoxDr(opts, cb) {
+    // only windows build is a zip
+    if (path.extname(opts.from) === '.zip') {
+      installZippedFile(opts.from, opts.to, cb);
+    } else {
+      installGzippedFile(opts.from, opts.to, cb);
+    }
+  }
+
+  function installGzippedFile(from, to, cb) {
+    getDownloadStream(from, function(err, stream) {
+      if (err) {
+        return cb(err);
+      }
+      // Store downloaded compressed file
+      var gzipWriteStream = fs.createWriteStream(to)
+        .once('error', cb.bind(null, new Error('Could not write to ' + to)));
+      stream.pipe(gzipWriteStream);
+
+      gzipWriteStream.once('finish', uncompressGzippedFile.bind(null, to, cb));
+    });
+  }
+
+  function uncompressGzippedFile(gzipFilePath, cb) {
+    var gunzip = require('zlib').createGunzip();
+    var extractPath = path.join(path.dirname(gzipFilePath), path.basename(gzipFilePath, '.gz'));
+    var writeStream = fs.createWriteStream(extractPath).once('error',
+      function(error) {
+        cb.bind(null, new Error('Could not write to ' + extractPath));
+      }
+    );
+    fs.createReadStream(gzipFilePath).pipe(gunzip).pipe(writeStream)
+      .once('error', cb.bind(null, new Error('Could not read ' + gzipFilePath)))
+      .once('finish', function() { cb() })
+    ;
+
+  }
+
   function installZippedFile(from, to, cb) {
     getDownloadStream(from, function(err, stream) {
       if (err) {
@@ -175,12 +225,14 @@ function install(opts, cb) {
       stream.pipe(zipWriteStream);
 
       // Uncompress downloaded file
-      zipWriteStream.once('finish', uncompressDownloadedFile.bind(null, to, cb));
+      zipWriteStream.once('finish',
+        uncompressDownloadedFile.bind(null, to, cb)
+      );
     });
   }
 
   function getDownloadStream(downloadUrl, cb) {
-    var r = request(downloadUrl)
+    var r = request(downloadUrl, {followAllRedirects: true})
       .on('response', function(res) {
         startedRequests += 1;
 
@@ -292,7 +344,7 @@ function chmodChromeDr(where, cb) {
 }
 
 function logInstallSummary(logger, paths, urls) {
-  ['selenium', 'chrome', 'ie'].forEach(function log(name) {
+  ['selenium', 'chrome', 'ie', 'firefox'].forEach(function log(name) {
     if (!paths[name]) {
       return;
     }
@@ -330,8 +382,7 @@ function unquote (str, quoteChar) {
 }
 
 function etag (url, cb) {
-  request.head(url).on('response', function (res) {
-
+  request.head(url, {followAllRedirects: true}).on('response', function (res) {
     if (res.statusCode !== 200) {
       return cb(new Error('Could not request headers from ' + url + ': ', res.statusCodestatusCode));
     }

--- a/lib/start.js
+++ b/lib/start.js
@@ -70,6 +70,10 @@ function start(opts, cb) {
     delete fsPaths.ie;
   }
 
+  if (fsPaths.firefox) {
+    args.push('-Dwebdriver.gecko.driver=' + fsPaths.firefox.installPath);
+  }
+
   args = args.concat(opts.seleniumArgs);
 
   checkPathsExistence(getInstallPaths(fsPaths), function(err) {


### PR DESCRIPTION
Required for Firefox 47+, supported for Firefox 45+

`geckodriver` executable is distributed as a .gz file for linux and osx,
so I've added a new gunzip workflow similar to the unzip workflow
